### PR TITLE
In summarize_results, handle empty groups gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ with the appropriate values.
 From the Arcs virtual environment created above, do the following:
 
 ```bash
-python setup.py test
+pip install pytest
+py.test
 ```
 
 ## Parsing server logs for query data

--- a/arcs/error_analysis.py
+++ b/arcs/error_analysis.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     print "Counting irrelevants"
 
     data_df["num_irrelevants"] = data_df["raw_judgments"].apply(
-        lambda js: sum([1 for j in js if j["judgment"] < 1]))
+        lambda js: sum([1 for j in js if "judgment" in j and j["judgment"] < 1]))
 
     data_df = data_df[data_df["num_irrelevants"] >= 2]
 

--- a/arcs/launch_job.py
+++ b/arcs/launch_job.py
@@ -55,7 +55,7 @@ def get_cetera_results(domain_query_pairs, cetera_host, cetera_port,
     params = frozendict(cetera_params)
 
     def _get_result_list(domain, query):
-        r = requests.get(url, params=params.copy(domains=domain, q=query))
+        r = requests.get(url, params=params.copy(search_context=domain, domains=domain, q=query))
         return [res for res in list(enumerate(r.json().get("results")))
                 if lang_filter(res[1]['resource'].get('description'))][:num_results]
 
@@ -173,6 +173,7 @@ def get_domain_image(domain):
 
         if not (url.startswith("http") or url.startswith("https")):
             url = "http://{0}{1}".format(domain, url)
+
         return url
 
     except IndexError as e:

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,8 @@ install_requires_list = ['pandas==0.17.0',
                          'langdetect==1.0.5',
                          'crowdflower==0.1.3',
                          'scipy==0.16.0',
-                         'spacy==0.95']
+                         'spacy==0.99']
 
-
-tests_require = ["pytest==2.6.4"]
 
 
 class PyTest(TestCommand):
@@ -65,5 +63,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=install_requires_list,
-    tests_require=tests_require,
+    setup_requires=['pytest-runner'],
+    tests_require=["pytest==2.6.4"],
     cmdclass={'test': PyTest})

--- a/tests/test_summarize_results.py
+++ b/tests/test_summarize_results.py
@@ -1,0 +1,22 @@
+import unittest
+import pandas as pd
+from arcs.summarize_results import per_query_ndcg
+
+
+class SummarizeResultsTest(unittest.TestCase):
+    def test_per_query_ndcg_on_all_empty_result_queries(self):
+        test_queries = ["2006", "2015", "291 erskine", "311", "330153"]
+
+        test_domains = ["data.kcmo.org", "data.detroitmi.gov", "datacatalog.cookcountyil.gov",
+                        "data.baltimorecity.gov", "data.medicare.gov"]
+
+        data_df = pd.DataFrame({"query": test_queries,
+                                "result_fxf": [None] * len(test_queries),
+                                "result_position": [None] * len(test_queries),
+                                "judgment": [None] * len(test_queries),
+                                "raw_judgments": [None] * len(test_queries)})
+        ideals_df = pd.DataFrame({"query": test_queries,
+                                  "domain": test_domains,
+                                  "judgments": [[3.0] * 10] * 5})
+
+        assert per_query_ndcg(data_df, ideals_df, 5) is None

--- a/tests/test_summarize_results.py
+++ b/tests/test_summarize_results.py
@@ -1,10 +1,10 @@
 import unittest
 import pandas as pd
-from arcs.summarize_results import per_query_ndcg
+from arcs.summarize_results import per_query_ndcg, stats
 
 
 class SummarizeResultsTest(unittest.TestCase):
-    def test_per_query_ndcg_on_all_empty_result_queries(self):
+    def setUp(self):
         test_queries = ["2006", "2015", "291 erskine", "311", "330153"]
 
         test_domains = ["data.kcmo.org", "data.detroitmi.gov", "datacatalog.cookcountyil.gov",
@@ -14,9 +14,24 @@ class SummarizeResultsTest(unittest.TestCase):
                                 "result_fxf": [None] * len(test_queries),
                                 "result_position": [None] * len(test_queries),
                                 "judgment": [None] * len(test_queries),
-                                "raw_judgments": [None] * len(test_queries)})
-        ideals_df = pd.DataFrame({"query": test_queries,
-                                  "domain": test_domains,
-                                  "judgments": [[3.0] * 10] * 5})
+                                "raw_judgments": [[]] * len(test_queries),
+                                "domain": test_domains})
+
+        self.all_zero_result_query_df = data_df
+
+        self.all_perfect_ideals_df = pd.DataFrame({"query": test_queries,
+                                                   "domain": test_domains,
+                                                   "judgments": [[3.0] * 10] * 5})
+
+    def test_per_query_ndcg_on_all_empty_result_queries(self):
+        data_df = self.all_zero_result_query_df
+        data_df = data_df[data_df["result_fxf"].notnull()]
+        ideals_df = self.all_perfect_ideals_df
 
         assert per_query_ndcg(data_df, ideals_df, 5) is None
+
+    def test_stats_on_all_empty_result_queries(self):
+        data_df = self.all_zero_result_query_df
+        ideals_df = self.all_perfect_ideals_df
+
+        assert stats(data_df, ideals_df)


### PR DESCRIPTION
Previously, if a group was empty (which would happen if, for example, there were no results for any queries in the group), then things would blow up when we went to summarize the results from the groups in our experiment. This PR address that issue, and adds a few related unit tests. Additionally, we ensure that search_context is being set in all requests to Cetera