### PR TITLE
Make Python3 friendly and support category facet relevance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,69 @@
-.DS_Store
-*.pyc
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*.swp
+
+# Specific ignores
+bak/
+tmp/
+old/
+venv/
+*.pickle
 *.csv
-*.json
-*.tsv
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+*.eggs
+wheelhouse/
+*~
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+.idea/
+.ipynb_checkpoints/

--- a/arcs/calc_iaa.py
+++ b/arcs/calc_iaa.py
@@ -37,7 +37,7 @@ def read_info(csv_file):
 
 def get_iaa(rows):
     missing = '*'  # indicator for missing values
-    print "IAA: %.3f" % krippendorff_alpha(info, preprocessed=True, metric=ordinal_metric, convert_items=int, missing_items=missing)
+    print("IAA: %.3f" % krippendorff_alpha(info, preprocessed=True, metric=ordinal_metric, convert_items=int, missing_items=missing))
 
 
 def arg_parser():

--- a/arcs/cetera.py
+++ b/arcs/cetera.py
@@ -1,0 +1,120 @@
+import logging
+import requests
+from frozendict import frozendict
+
+from collect_domain_query_data import lang_filter
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Query(object):
+    @property
+    def text(self):
+        return self._text
+
+    @classmethod
+    def from_query_str(cls, q):
+        parts = q.split('=')
+        return FacetSearch(parts[0], parts[1]) if len(parts) == 2 else KeywordSearch(q)
+
+    def to_query_params(self):
+        pass
+
+
+class KeywordSearch(Query):
+    def __init__(self, text):
+        self._text = text
+
+    def to_query_params(self):
+        return {"q": self._text}
+
+    def __str__(self):
+        return self.text
+
+    __repr__ = __str__
+
+
+def prepare_facet(facet):
+    if facet == "category":
+        prepared = "categories"
+    else:
+        prepared = facet
+
+    return prepared
+
+
+class FacetSearch(Query):
+    def __init__(self, facet, text):
+        super(Query, self)
+        self._facet = facet
+        self._text = text
+
+    @property
+    def facet(self):
+        return self._facet
+
+    def to_query_params(self):
+        return {prepare_facet(self.facet): self.text}
+
+    def __str__(self):
+        return "{}={}".format(self.facet, self.text)
+
+    __repr__ = __str__
+
+
+def get_cetera_results(domain_query_pairs, cetera_host, cetera_port,
+                       num_results=10, cetera_params=None,
+                       filter_too_few_results=False):
+    """
+    Get the top n=num_results catalog search results from Cetera for each
+    (domain, query) pair in domain_query_pairs.
+
+    Args:
+        domain_query_pairs (Iterable[(str, Query)]): An iterable of domain-query pairs
+        cetera_host (str): The Cetera hostname
+        cetera_port (int): The port on which to make requests to Cetera
+        num_results (int): The number of results to fetch for each query
+        cetera_params (Dict[Any, Any]): Optional, additional query parameters for Cetera
+        filter_too_few_results (bool): Whether to filter queries with too few results
+
+    Returns:
+        A list of (domain, Query, result dict) triples
+    """
+    LOGGER.info("Getting search results from Cetera")
+
+    if cetera_host and cetera_port:
+        url = "http://{}:{}/catalog".format(cetera_host, cetera_port)
+    else:
+        url = "http://api.us.socrata.com/api/catalog"
+
+    cetera_params = cetera_params or {}
+    cetera_params.update({"limit": num_results * 2})  # 2x because we're going to langfilter
+
+    params = frozendict(cetera_params)
+
+    def _get_result_list(domain, query):
+        if domain and domain != "www.opendatanetwork.com":
+            params_ = params.copy(search_context=domain, domains=domain)
+        else:
+            params_ = params.copy()
+
+        params_ = params_.copy(**query.to_query_params())
+
+        r = requests.get(url, params=params_)
+
+        return [res for res in list(enumerate(r.json().get("results")))
+                if lang_filter(res[1]['resource'].get('description'))][:num_results]
+
+    # make Query objects from query strings
+    domain_query_pairs_ = ((d, Query.from_query_str(q)) for (d, q) in domain_query_pairs)
+
+    # get results for each domain, query pair
+    res = [(d, q, _get_result_list(d, q)) for d, q in domain_query_pairs_]
+
+    # filter for only the (d, q, result_list) tuples that have at least
+    # num_results results
+    if filter_too_few_results:
+        filtered = [(d, q, rl) for d, q, rl in res if len(rl) >= num_results]
+        res = filtered
+
+    return res

--- a/arcs/collect_domain_query_data.py
+++ b/arcs/collect_domain_query_data.py
@@ -263,7 +263,7 @@ if __name__ == "__main__":
         db_conn, args.query_logs_json, args.num_domains, args.queries_per_domain,
         query_blacklist_file=args.query_blacklist, query_filters=query_filters)
 
-    print "domain\tquery\tcount"
+    print("domain\tquery\tcount")
 
     for (domain, query, count) in domain_queries:
-        print "{}\t{}\t{}".format(domain, query.encode("utf-8"), count)
+        print("{}\t{}\t{}".format(domain, query.encode("utf-8"), count))

--- a/arcs/crowdflower.py
+++ b/arcs/crowdflower.py
@@ -34,7 +34,8 @@ def job_from_dict(job_data):
 
     return Job(**data)
 
-headers = frozendict({'content-type': 'application/json', 'accept': 'application/json'})
+headers = frozendict({'content-type': 'application/json; charset=utf-8',
+                      'accept': 'application/json; charset=utf-8'})
 
 
 def create_job_from_copy(api_key=None, job_id=None):
@@ -48,7 +49,7 @@ def create_job_from_copy(api_key=None, job_id=None):
     Returns:
         A new Job
     """
-    job_id = job_id or 911851
+    job_id = job_id or 911946
     api_key = api_key or os.environ["CROWDFLOWER_API_KEY"]
     url = "https://api.crowdflower.com/v1/jobs/{}/copy.json?key={}&gold=true".format(
         job_id, api_key)
@@ -68,6 +69,7 @@ def add_data_to_job(job_id, csv_file, api_key=None):
         api_key (str): API token (use "CROWDFLOWER_API_KEY" env variable if not specified)
     """
     api_key = api_key or os.environ["CROWDFLOWER_API_KEY"]
+
     url = "https://api.crowdflower.com/v1/jobs/{}/upload.json?key={}&force=true".format(
         job_id, api_key)
 

--- a/arcs/crowdflower.py
+++ b/arcs/crowdflower.py
@@ -5,10 +5,10 @@ import requests
 import simplejson
 import time
 import zipfile
-import StringIO
 from dateutil.parser import parse as dtparse
-from frozendict import frozendict
 from experiment import Job
+from frozendict import frozendict
+from io import StringIO
 
 
 FXF_RE = re.compile(r'[a-z0-9]{4}-[a-z0-9]{4}$')
@@ -46,11 +46,13 @@ def create_job_from_copy(api_key=None, job_id=None):
         job_id (int): The unique job identifier of the job to copy
 
     Returns:
-        A new Arcs Job
+        A new Job
     """
-    job_id = job_id or 844991
+    job_id = job_id or 911851
     api_key = api_key or os.environ["CROWDFLOWER_API_KEY"]
-    url = "https://api.crowdflower.com/v1/jobs/{}/copy.json?key={}&gold=true".format(job_id, api_key)
+    url = "https://api.crowdflower.com/v1/jobs/{}/copy.json?key={}&gold=true".format(
+        job_id, api_key)
+
     r = requests.get(url, headers=headers)
     r.raise_for_status()
     return job_from_dict(r.json())
@@ -66,7 +68,9 @@ def add_data_to_job(job_id, csv_file, api_key=None):
         api_key (str): API token (use "CROWDFLOWER_API_KEY" env variable if not specified)
     """
     api_key = api_key or os.environ["CROWDFLOWER_API_KEY"]
-    url = "https://api.crowdflower.com/v1/jobs/{}/upload.json?key={}&force=true".format(job_id, api_key)
+    url = "https://api.crowdflower.com/v1/jobs/{}/upload.json?key={}&force=true".format(
+        job_id, api_key)
+
     with open(csv_file) as f:
         r = requests.put(url, data=f, headers=headers.copy(**{"content-type": "text/csv"}))
     r.raise_for_status()

--- a/arcs/crowdflower.py
+++ b/arcs/crowdflower.py
@@ -38,18 +38,17 @@ headers = frozendict({'content-type': 'application/json; charset=utf-8',
                       'accept': 'application/json; charset=utf-8'})
 
 
-def create_job_from_copy(api_key=None, job_id=None):
+def create_job_from_copy(job_id, api_key=None):
     """
     Create a new CrowdFlower job from a previous job, copying existing test questions.
 
     Args:
-        api_key (str): Optional CrowdFlower API key; if not specified, we look in env.
         job_id (int): The unique job identifier of the job to copy
+        api_key (str): Optional CrowdFlower API key; if not specified, we look in env.
 
     Returns:
         A new Job
     """
-    job_id = job_id or 911946
     api_key = api_key or os.environ["CROWDFLOWER_API_KEY"]
     url = "https://api.crowdflower.com/v1/jobs/{}/copy.json?key={}&gold=true".format(
         job_id, api_key)
@@ -70,11 +69,17 @@ def add_data_to_job(job_id, csv_file, api_key=None):
     """
     api_key = api_key or os.environ["CROWDFLOWER_API_KEY"]
 
-    url = "https://api.crowdflower.com/v1/jobs/{}/upload.json?key={}&force=true".format(
-        job_id, api_key)
+    url = "https://api.crowdflower.com/v1/jobs/{}/upload.json".format(job_id)
+
+    params = {"key": api_key, "force": True}
 
     with open(csv_file) as f:
-        r = requests.put(url, data=f, headers=headers.copy(**{"content-type": "text/csv"}))
+        r = requests.put(
+            url,
+            data=f,
+            params=params,
+            headers=headers.copy(**{"content-type": "text/csv"}))
+
     r.raise_for_status()
 
 

--- a/arcs/crowdflower.py
+++ b/arcs/crowdflower.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os
 import re
@@ -8,7 +9,6 @@ import zipfile
 from dateutil.parser import parse as dtparse
 from experiment import Job
 from frozendict import frozendict
-from io import StringIO
 
 
 FXF_RE = re.compile(r'[a-z0-9]{4}-[a-z0-9]{4}$')
@@ -162,7 +162,7 @@ def extract_json_from_csv(zip_data):
     full_json = {}
 
     for i, line in enumerate(zip_data):
-        unit = simplejson.loads(line)
+        unit = simplejson.loads(line.decode("utf-8"))
         full_json[i] = unit  # fix this
         data = unit.get('data')
         query = data.get('query')
@@ -210,7 +210,7 @@ def get_job_results(job_id, api_key=None):
             ret = requests.get(filled_get_url)
             # we are returning a bytestring that would be a zipfile, were it a file
             # containing a single file where each line is a json blob
-            zc = zipfile.ZipFile(StringIO.StringIO(ret.content))
+            zc = zipfile.ZipFile(io.BytesIO(ret.content))
             zip_data = zc.open(zc.namelist()[0])
             if zip_data:
                 break

--- a/arcs/crowdsourcing_utils.py
+++ b/arcs/crowdsourcing_utils.py
@@ -1,0 +1,336 @@
+import logging
+import os
+import re
+import requests
+import simplejson as json
+from datetime import datetime
+from itertools import chain
+from requests import HTTPError
+from requests.exceptions import SSLError
+from spacy.en import English
+
+CROWDFLOWER_MAX_ROW_LENGTH = 32767
+_LOGO_UID_RE = re.compile(r"^[A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}$")
+
+LOGGER = logging.getLogger(__name__)
+
+NLP = English()
+SOCRATA_APP_TOKEN = os.environ.get("SOCRATA_APP_TOKEN")
+
+
+def get_domain_image(domain):
+    """
+    Get the site logo for the specified domain.
+
+    Args:
+        domain (str): The domain cname
+
+    Returns:
+        A URL to the domain's logo
+    """
+    url = 'http://{0}/api/configurations.json'.format(domain)
+
+    params = {'type': 'site_theme',
+              'defaultOnly': True,
+              'merge': True}
+
+    response = None
+
+    try:
+        response = requests.get(url, params=params, timeout=(5, 10))
+        response.encoding = 'utf-8'
+        response.raise_for_status()
+
+        data = next((x for x in response.json()[0]["properties"]
+                     if "name" in x and x["name"] == "theme_v2b"))
+
+        url = data.get("value", {}).get("images", {}).get("logo_header", {}) \
+                                                     .get("href")
+
+        if url and _LOGO_UID_RE.match(url):
+            url = "/api/assets/{0}".format(url)
+
+        if not (url.startswith("http") or url.startswith("https")):
+            url = "http://{0}{1}".format(domain, url)
+
+        return url
+
+    except IndexError as e:
+        print("Unexpected result shape: zero elements in response JSON")
+        print("Response: {}".format(response.content if response else None))
+        print("Exception: {}".format(e.message))
+    except StopIteration as e:
+        print("Unable to find image properties in response JSON")
+        print("Response: {}".format(response.content if response else None))
+        print("Exception: {}".format(e.message))
+    except Exception as e:
+        print("Failed to fetch configuration for %s" % domain)
+        print("Response: %s" % response.content if response else None)
+        print("Exception: %s" % e.message)
+
+
+def gather_columns_types(domain, fxf):
+    """
+    Gather the column headers and their types
+
+    Args:
+        domain (str): A domain cname
+        fxf (str): An identifier for a dataset
+
+    Returns:
+        A list of pairs of containing a column name and a column type
+    """
+    url = 'http://{}/api/views/{}/columns.json'.format(domain, fxf)    
+
+    try:
+        response = requests.get(url)
+    except SSLError:
+        LOGGER.error(
+            "SSLError occurred while gathering column types for {} from domain {}".format(
+                fxf, domain))
+        response = None
+
+    column_types = []
+
+    if response:
+        try:
+            response.raise_for_status()
+        except HTTPError:
+            response_body = []
+        else:
+            response_body = response.json()
+
+            if isinstance(response_body, dict) and "error" in response_body:
+                response_body = []
+
+        def extract(column):
+            return (column.get("name"), column.get("fieldName"), column.get("dataTypeName"))
+
+        column_types = [extract(column) for column in response_body]
+
+    return column_types
+
+
+def convert_to_table(header, rows):
+    """
+    Create an HTML table out of the sample data.
+
+    Args:
+        header (str): The table header
+        rows (List[str]): A list of rows as strings
+
+    Returns:
+        A dataset sample in the form of an HTML <table>
+    """
+    header_html = '<tr><th>{}</th></tr>'.format('</th><th>'.join(header))
+    rows_html = ['<tr><td>{}</td></tr>'.format('</td><td>'.join(row)) for row in rows]
+
+    if rows:
+        table = '<table>{header}\n{rows}</table>'.format(
+            header=header_html, rows='\n'.join(rows_html))
+    else:
+        table = None
+
+    return table
+
+
+def _join_sentences(acc, sentences, max_length):
+    if len(sentences) > 0 and len(acc + " " + sentences[0]) < max_length:
+        return _join_sentences(acc + " " + sentences.pop(0), sentences, max_length)
+    else:
+        return acc.strip()
+
+
+def cleanup_description(desc, nlp=None):
+    """
+    Make a dataset description is readable and not ridiculously long.
+
+    Args:
+        desc (str): A dataset (or other core object) description
+
+    Returns:
+        Returns a trimmed version of the description, containing as many sentences from the
+        description as can fit in a string without exceeding 400 characters
+    """
+    analyzer = nlp or NLP
+    desc = desc.replace("\r", "\n")
+    desc_doc = analyzer(desc) if desc else desc
+    desc_sentences = [s.text.replace("\n", " ").strip() for s in desc_doc.sents] if desc else []
+
+    return _join_sentences("", desc_sentences, 400) if desc else desc
+
+
+def extract_address(cell_contents):
+    """
+    If the cell data is an address, extract the user-friendly bits of it.
+
+    Args:
+        cell_contents (Any): The contents of a cell
+
+    Returns:
+        A friendly address when one is extractable
+    """
+    LOGGER.debug("Extracting address from {}".format(cell_contents))
+
+    if "human_address" in cell_contents:
+        ad = json.loads(cell_contents["human_address"])
+        fields = [ad.get('address'), ad.get('city'), ad.get('state'), ad.get('zip')]
+        non_null_fields = [str(f) for f in fields if f]
+    elif "latitude" in cell_contents and "longitude" in cell_contents:
+        ad = (cell_contents.get("latitude"), cell_contents.get("longitude"))
+        if ad[0] and ad[1]:
+            non_null_fields = ["(" + ad[0], ad[1] + ")"]
+    else:
+        non_null_fields = []
+
+    s = ', '.join(non_null_fields)
+
+    return s
+
+
+def stringify(cell_contents):
+    """
+    Extract user-friendly strings from cell contents.
+
+    Args:
+        cell_contents (Any): The contents of a cell
+
+    Returns:
+        The cell contents as a string
+    """
+    def flatten(d, parent_key='', sep='_'):
+        items = []
+        for k, v in d.items():
+            new_key = parent_key + sep + k if parent_key else k
+            if isinstance(v, dict):
+                items.extend(flatten(v, new_key, sep=sep).items())
+            else:
+                items.append((new_key, v))
+        return dict(items)
+
+    def is_list_of_dicts(cell_contents):
+        return isinstance(cell_contents[0], dict)
+
+    def str_(v):
+        return ("%.2f" % v) if isinstance(v, float) else str(v)
+
+    if isinstance(cell_contents, list):
+        if is_list_of_dicts(cell_contents):
+            strs_to_join = chain.from_iterable([flatten(d).values() for d in cell_contents])
+        else:
+            strs_to_join = [str_(value) for value in cell_contents if value]
+
+        stringified = ', '.join(strs_to_join)
+    else:
+        stringified = str(cell_contents)
+
+    return stringified
+
+
+def _replace_hexadecimal_str(s):
+    """
+    Replace "\xe8"-type strings with a single hyphen.
+    """
+    unicodey = r'\\x[abcdef0-9]{2}'
+
+    return re.sub(unicodey, '-', s)
+
+
+def convert_row(column_name_type, row):
+    """
+    Make cell data more user friendly.
+
+    Args:
+        column_name_type (List[(str, str)]): A list of pairs of column names and types
+        row (dict): The row data as a dict
+
+    Returns:
+        A list containing row data transformed to be more user-friendly
+    """
+    row_converted = []
+
+    for column_name, column_type in column_name_type:
+        contents = row.get(column_name)
+        if not contents or not column_type:
+            contents = " "
+        else:
+            if 'date' in column_type and str(contents).isdigit():
+                contents = datetime.fromtimestamp(int(contents)).strftime('%Y-%m-%d')
+            elif 'money' in column_type:
+                # EVERYBODY IS IN AMERICA RIGHT
+                contents = '${}'.format(contents)
+            elif 'location' in column_type:
+                contents = extract_address(contents)
+            else:
+                contents = stringify(contents)
+
+        contents = _replace_hexadecimal_str(contents)
+
+        row_converted.append(contents)
+
+    return row_converted
+
+
+def gather_rows(domain, fxf, columns_names, columns_types, num_rows):
+    """
+    Gather some sample rows from this dataset to create a short snippet of a dataset.
+
+    Args:
+        domain (str): A domain cname
+        fxf (str): An identifier for a dataset
+        columns_names (List[str]): A list of column names
+        columns_types (List[str]): A list of column types
+        num_rows (int): The number of rows to gather
+
+    Returns:
+        A list of rows representing a sample of rows and columns from a selected dataset
+    """
+    headers = {"X-App-Token": SOCRATA_APP_TOKEN}
+
+    url = 'https://{}/resource/{}.json?$select={}&$limit={}'.format(
+        domain, fxf, ','.join(columns_names), num_rows)
+
+    def get_row_data():
+        try:
+            response = requests.get(url, headers=headers)
+        except SSLError:
+            LOGGER.error(
+                "SSLError occurred while gathering row data for {} from domain {}".format(
+                    fxf, domain))
+            response = None
+
+        rowdata = []
+
+        if response:
+            try:
+                response.raise_for_status()
+            except HTTPError:
+                rowdata = []
+            else:
+                response_body = response.json()
+                rowdata = [x for x in response_body if x]
+
+        return rowdata
+
+    column_name_type = list(zip(columns_names, columns_types))
+    return [convert_row(column_name_type, row) for row in get_row_data()]
+
+
+def make_dataset_sample(domain_cname, fxf, num_rows, num_columns):
+    """
+    Make a sample HTML table for a dataset, with `num_rows` rows and `num_columns` columns.
+
+    Args:
+        domain_cname (str): A domain cname
+        fxf (str): An identifier for a dataset
+        num_rows (int): The number of rows to show in the dataset sample
+        num_columns (int): The number of columns to show in the dataset sample
+
+    Returns:
+        An HTML table as a string
+    """
+    columns_types = gather_columns_types(domain_cname, fxf)[:num_columns]
+    header, columns_names, datatypes = zip(*columns_types) if columns_types else ([], [], [])
+    rows = gather_rows(domain_cname, fxf, columns_names, datatypes, num_rows)
+    table = convert_to_table(header, rows)
+    return table if table and len(table) < CROWDFLOWER_MAX_ROW_LENGTH else None

--- a/arcs/crowdsourcing_utils.py
+++ b/arcs/crowdsourcing_utils.py
@@ -143,7 +143,7 @@ def _join_sentences(acc, sentences, max_length):
 
 def cleanup_description(desc, nlp=None):
     """
-    Make a dataset description is readable and not ridiculously long.
+    Make sure a dataset description is readable and not ridiculously long.
 
     Args:
         desc (str): A dataset (or other core object) description
@@ -155,7 +155,7 @@ def cleanup_description(desc, nlp=None):
     analyzer = nlp or NLP
     desc = desc.replace("\r", "\n")
     desc_doc = analyzer(desc) if desc else desc
-    desc_sentences = [s.text.replace("\n", " ").strip() for s in desc_doc.sents] if desc else []
+    desc_sentences = [re.sub(r"\s+", " ", s.text).strip() for s in desc_doc.sents] if desc else []
 
     return _join_sentences("", desc_sentences, 400) if desc else desc
 

--- a/arcs/error_analysis.py
+++ b/arcs/error_analysis.py
@@ -113,39 +113,39 @@ if __name__ == "__main__":
 
     db_conn = psycopg2.connect(args.db_conn_str)
 
-    print "Reading metadata"
+    print("Reading metadata")
 
     fxf_metadata_dict = get_fxf_metadata_mapping(db_conn)
 
-    print "Reading all judged data for group"
+    print("Reading all judged data for group")
 
     data_df = pd.read_sql(
         group_queries_and_judgments_query(db_conn, args.group_id, "domain_catalog"),
         db_conn)
 
-    print "Counting irrelevants"
+    print("Counting irrelevants")
 
     data_df["num_irrelevants"] = data_df["raw_judgments"].apply(
         lambda js: sum([1 for j in js if "judgment" in j and j["judgment"] < 1]))
 
     data_df = data_df[data_df["num_irrelevants"] >= 2]
 
-    print "Adding metadata to dataframe"
+    print("Adding metadata to dataframe")
 
     data_df["metadata"] = data_df["result_fxf"].apply(
         lambda fxf: fxf_metadata_dict.get(fxf, {}))
 
-    print "Extracting dataset names"
+    print("Extracting dataset names")
 
     data_df["name"] = data_df["metadata"].apply(
         lambda metadata: metadata.get("name"))
 
-    print "Extracting and cleaning descriptions"
+    print("Extracting and cleaning descriptions")
 
     data_df["description"] = data_df["metadata"].apply(
         lambda metadata: cleanup_description(metadata.get("description", "").decode("utf-8")))
 
-    print "Extracting URLs"
+    print("Extracting URLs")
 
     data_df["url"] = data_df.apply(
         lambda row: get_dataset_url(

--- a/arcs/fetch_job_results.py
+++ b/arcs/fetch_job_results.py
@@ -12,6 +12,10 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 # wrappers for them, and then add them to this list
 ALLOWED_CROWDSOURCE_PLATFORMS = frozenset(('crowdflower',))
 
+logging.basicConfig(format='%(message)s', level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+logging.getLogger("requests").setLevel(logging.WARNING)
+
 
 def create_tables(conn, sql_file=None):
     """
@@ -51,14 +55,14 @@ def get_job_data(crowdsource_platform, external_job_id, api_key=None):
         data (list): list of dicts of (query, result_fxf, judgment)
         full_json (dict): the full return content from crowdflower, keyed by line number
     """
-    logging.info("Gathering data and metadata from {}".format(crowdsource_platform))
+    LOGGER.info("Gathering data and metadata from {}".format(crowdsource_platform))
 
     if crowdsource_platform == 'crowdflower':
         api_key = api_key or os.environ['CROWDFLOWER_API_KEY']
         metadata, job_created_at, job_completed_at = get_job_metadata(external_job_id, api_key)
         data, full_json = get_job_results(external_job_id, api_key)
     else:
-        logging.error('Unexpected crowdsource_platform {}, \
+        LOGGER.error('Unexpected crowdsource_platform {}, \
         must be one of {}'.format(crowdsource_platform,
                                   ALLOWED_CROWDSOURCE_PLATFORMS))
         raise ValueError("Unexpected crowdsource_platform={}".format(crowdsource_platform))
@@ -103,7 +107,6 @@ def main(args):
 
 if __name__ == "__main__":
     psycopg2.extensions.register_adapter(dict, psycopg2.extras.Json)
-    logging.basicConfig(level=logging.INFO)
 
     parser = argparse.ArgumentParser(description='Take data from a crowdsourcing platform '
                                      'and upload it to a postgres database')

--- a/arcs/fetch_job_results.py
+++ b/arcs/fetch_job_results.py
@@ -87,7 +87,7 @@ def main(args):
     """
     - Create a connection to RDS
     - Download result data from {crowdsource_platform} given external job ID
-    - Insert results into various RDS tables
+    - Persist results
 
     Args:
         args (argparse.Namespace): input argument k:v pairs

--- a/arcs/krippendorff_alpha.py
+++ b/arcs/krippendorff_alpha.py
@@ -125,7 +125,7 @@ def krippendorff_alpha(data, metric=interval_metric, preprocessed=False, force_v
     return 1. - Do/De
 
 if __name__ == '__main__':
-    print "Example from http://en.wikipedia.org/wiki/Krippendorff's_Alpha"
+    print("Example from http://en.wikipedia.org/wiki/Krippendorff's_Alpha")
 
     data = (
         "*    *    *    *    *    3    4    1    2    1    1    3    3    *    3",  # coder A
@@ -136,7 +136,7 @@ if __name__ == '__main__':
     missing = '*'  # indicator for missing values
     array = [d.split() for d in data]  # convert to 2D list of string items
 
-    print "nominal metric: %.3f" % krippendorff_alpha(array, nominal_metric, missing_items=missing)
-    print "interval metric: %.3f" % krippendorff_alpha(array, interval_metric, missing_items=missing)
-    print "ratio metric: %.3f" % krippendorff_alpha(array, ratio_metric, missing_items=missing)
-    print "ordinal metric: %.3f" % krippendorff_alpha(array, metric=ordinal_metric, convert_items=intify_floats, missing_items=missing)
+    print("nominal metric: %.3f" % krippendorff_alpha(array, nominal_metric, missing_items=missing))
+    print("interval metric: %.3f" % krippendorff_alpha(array, interval_metric, missing_items=missing))
+    print("ratio metric: %.3f" % krippendorff_alpha(array, ratio_metric, missing_items=missing))
+    print("ordinal metric: %.3f" % krippendorff_alpha(array, metric=ordinal_metric, convert_items=intify_floats, missing_items=missing))

--- a/arcs/launch_job.py
+++ b/arcs/launch_job.py
@@ -1,413 +1,115 @@
+"""
+Create a CrowdFlower job to collect relevance judments for domain, query pairs.
+
+This script will read a file of domain, query pairs from the command-line, and collect results from
+Cetera for each pair. You may optionally specify different experimental groups (eg. baseline
+vs. experiment1) via the `-g` option. These should be specified as JSON strings.
+
+Example:
+
+    python arcs/launch_job.py \
+        -i ~/Data/arcs/20160126.experiment_1/queries.tsv \
+        -g '{"name": "adjusted boost clause", "description": "Moved field boosts to 'should' clause", "params": {}}' \
+        -r 10 \
+        -D 'postgresql://username:password@hostname/dbname'
+
+The group definition should have a name, description, and params field. The params field should be
+a nested object specifying any relevant parameters of the experiment.
+
+A full CSV is created, which contains all of the job data. Additionally, a CrowdFlower CSV is
+created which corresponds precisely with the data uploaded to create the job in CrowdFlower.
+
+All data is persisted in a Postgres database, the parameters of which are specified via the -D
+option.
+"""
 import argparse
-import os
 import pandas as pd
-import requests
 import logging
-import re
 import psycopg2
-import simplejson as json
-from itertools import chain
-from requests import HTTPError
-from spacy.en import English, LOCAL_DATA_DIR
-from frozendict import frozendict
+from functools import partial
 from datetime import datetime
-from experiment import GroupDefinition
-from db import find_judged_qrps, insert_incomplete_job, add_raw_group_results
-from db import insert_unjudged_data_for_group, insert_empty_group
+
+from cetera import get_cetera_results
 from crowdflower import create_job_from_copy, add_data_to_job
-from collect_domain_query_data import lang_filter
+from crowdsourcing_utils import cleanup_description, make_dataset_sample
+from db import (
+    find_judged_qrps, insert_incomplete_job, add_raw_group_results,
+    insert_unjudged_data_for_group, insert_empty_group
+)
+from experiment import GroupDefinition
 
-data_dir = os.environ.get('SPACY_DATA', LOCAL_DATA_DIR)
-nlp = English(data_dir=data_dir)
 
-CORE_COLUMNS = ['domain', 'query', 'result_fxf', 'result_position', 'group_id', '_golden']
-DISPLAY_DATA = ['domain_logo_url', 'name', 'link', 'description']
+CORE_COLUMNS = ['domain', 'query', 'result_fxf', 'result_position', 'group_id']
+DISPLAY_DATA = ['name', 'link', 'description', 'sample']
 CSV_COLUMNS = CORE_COLUMNS + DISPLAY_DATA
 RAW_COLUMNS = ['domain', 'query', 'results', 'group_id']
-SOCRATA_APP_TOKEN = None
 
 logging.basicConfig(format='%(message)s', level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
+logging.getLogger("requests").setLevel(logging.WARNING)
 
 
-def get_cetera_results(domain_query_pairs, cetera_host, cetera_port,
-                       num_results=10, cetera_params=None,
-                       filter_too_few_results=False):
-    """
-    Get the top n=num_results catalog search results from Cetera for each
-    (domain, query) pair in domain_query_pairs.
-
-    Args:
-        domain_query_pairs (iterable): An iterable of domain-query pairs
-        cetera_host (str): The Cetera hostname
-        cetera_port (int): The port on which to make requests to Cetera
-        num_results (int): The number of results to fetch for each query
-        cetera_params (dict): Optional, additional query parameters for Cetera
-        filter_too_few_results (bool): Whether to filter queries with too few results
-
-    Returns:
-        A list of (domain, query, result dict) triples
-    """
-    LOGGER.info("Getting search results from Cetera")
-
-    # we can't use the port in this version
-    if 'https://api.us.socrata.com/api/catalog' in cetera_host:
-        url = cetera_host
-    else:
-        url = "http://{}:{}/catalog".format(cetera_host, cetera_port)
-
-    cetera_params = cetera_params or {}
-    cetera_params.update({"limit": num_results * 2})  # 2x because we're going to langfilter
-
-    params = frozendict(cetera_params)
-
-    def _get_result_list(domain, query):
-        if domain:
-            params_ = params.copy(search_context=domain, domains=domain, q=query)
-        else:
-            params_ = params.copy(q=query)
-
-        r = requests.get(url, params=params_)
-        return [res for res in list(enumerate(r.json().get("results")))
-                if lang_filter(res[1]['resource'].get('description'))][:num_results]
-
-    res = [(d, q, _get_result_list(d, q)) for d, q in domain_query_pairs]
-
-    # filter for only the (d, q, result_list) tuples that have at least
-    # num_results results
-    if filter_too_few_results:
-        filtered = [(d, q, rl) for d, q, rl in res if len(rl) >= num_results]
-        res = filtered
-
-    return res
-
-
-def _join_sentences(acc, sentences, max_length):
-    if len(sentences) > 0 and len(acc + " " + sentences[0]) < max_length:
-        return _join_sentences(acc + " " + sentences.pop(0), sentences, max_length)
-    else:
-        return acc.strip()
-
-
-def cleanup_description(desc):
-    """
-    Make a dataset description is readable and not ridiculously long.
-
-    Args:
-        desc (str): A dataset (or other core object) description
-
-    Returns:
-        Returns a trimmed version of the description, containing as many sentences from the
-        description as can fit in a string without exceeding 400 characters
-    """
-    desc = desc.replace("\r", "\n")
-    desc_doc = nlp(desc) if desc else desc
-    desc_sentences = [s.text.replace("\n", " ").strip() for s in desc_doc.sents] if desc else []
-
-    return _join_sentences("", desc_sentences, 400) if desc else desc
-
-
-def extract_address(cell_contents):
-    """
-    If the cell data is an address, extract the user-friendly bits of it.
-
-    Args:
-        cell_contents (Any): The contents of a cell
-
-    Returns:
-        A friendly address when one is extractable
-    """
-    LOGGER.debug("Extracting address from {}".format(cell_contents))
-
-    if "human_address" in cell_contents:
-        ad = json.loads(cell_contents["human_address"])
-        fields = [ad.get('address'), ad.get('city'), ad.get('state'), ad.get('zip')]
-        non_null_fields = [str(f) for f in fields if f]
-    elif "latitude" in cell_contents and "longitude" in cell_contents:
-        ad = (cell_contents.get("latitude"), cell_contents.get("longitude"))
-        if ad[0] and ad[1]:
-            non_null_fields = ["(" + ad[0], ad[1] + ")"]
-    else:
-        non_null_fields = []
-
-    s = ', '.join(non_null_fields)
-
-    return s
-
-
-def stringify(cell_contents):
-    """
-    Extract user-friendly strings from cell contents.
-
-    Args:
-        cell_contents (Any): The contents of a cell
-
-    Returns:
-        The cell contents as a string
-    """
-    def flatten(d, parent_key='', sep='_'):
-        items = []
-        for k, v in d.items():
-            new_key = parent_key + sep + k if parent_key else k
-            if isinstance(v, dict):
-                items.extend(flatten(v, new_key, sep=sep).items())
-            else:
-                items.append((new_key, v))
-        return dict(items)
-
-    def is_list_of_dicts(cell_contents):
-        return isinstance(cell_contents[0], dict)
-
-    def str_(v):
-        return ("%.2f" % v) if isinstance(v, float) else str(v)
-
-    if isinstance(cell_contents, list):
-        if is_list_of_dicts(cell_contents):
-            strs_to_join = chain.from_iterable([flatten(d).values() for d in cell_contents])
-        else:
-            strs_to_join = [str_(value) for value in cell_contents if value]
-
-        stringified = ', '.join(strs_to_join)
-    else:
-        stringified = str(cell_contents)
-
-    return stringified
-
-
-def _replace_hexadecimal_str(s):
-    """
-    Replace "\xe8"-type strings with a single hyphen.
-    """
-    unicodey = r'\\x[abcdef0-9]{2}'
-
-    return re.sub(unicodey, '-', s)
-
-
-def convert_row(column_name_type, row):
-    """
-    Make cell data more user friendly.
-
-    Args:
-        column_name_type (List[(str, str)]): A list of pairs of column names and types
-        row (dict): The row data as a dict
-
-    Returns:
-        A list containing row data transformed to be more user-friendly
-    """
-    row_converted = []
-
-    for column_name, column_type in column_name_type:
-        contents = row.get(column_name)
-        if not contents or not column_type:
-            contents = " "
-        else:
-            if 'date' in column_type and str(contents).isdigit():
-                contents = datetime.fromtimestamp(int(contents)).strftime('%Y-%m-%d')
-            elif 'money' in column_type:
-                # EVERYBODY IS IN AMERICA RIGHT
-                contents = '${}'.format(contents)
-            elif 'location' in column_type:
-                contents = extract_address(contents)
-            else:
-                contents = stringify(contents)
-
-        contents = _replace_hexadecimal_str(contents)
-
-        row_converted.append(contents)
-
-    return row_converted
-
-
-def gather_rows(domain, fxf, columns_names, columns_types, num_rows):
-    """
-    Gather some sample rows from this dataset to create a short snippet of a dataset.
-
-    Args:
-        domain (str): A domain cname
-        fxf (str): An identifier for a dataset
-        columns_names (List[str]): A list of column names
-        columns_types (List[str]): A list of column types
-        num_rows (int): The number of rows to gather
-
-    Returns:
-        A list of rows representing a sample of rows and columns from a selected dataset
-    """
-    headers = {"X-App-Token": SOCRATA_APP_TOKEN}
-
-    url = 'https://{}/resource/{}.json?$select={}&$limit={}'.format(
-        domain, fxf, ','.join(columns_names), num_rows)
-
-    def get_row_data():
-        response = requests.get(url, headers=headers)
-
-        try:
-            response.raise_for_status()
-        except HTTPError:
-            rowdata = []
-        else:
-            response_body = response.json()
-            rowdata = [x for x in response_body if x]
-
-        return rowdata
-
-    column_name_type = list(zip(columns_names, columns_types))
-    return [convert_row(column_name_type, row) for row in get_row_data()]
-
-
-def convert_to_table(header, rows, cell_padding=5):
-    """
-    Create an HTML table out of the sample data.
-
-    Args:
-        header (str): The table header
-        rows (List[str]): A list of rows as strings
-
-    Returns:
-        A dataset sample in the form of an HTML <table>
-    """
-    header_html = '<tr><th>{}</th></tr>'.format('</th><th>'.join(header))
-    rows_html = ['<tr><td>{}</td></tr>'.format('</td><td>'.join(row)) for row in rows]
-
-    if rows:
-        table = '<table cellpadding="{cellpadding}">{header}\n{rows}</table>'.format(
-            cellpadding=cell_padding, header=header_html, rows='\n'.join(rows_html))
-    else:
-        table = None
-
-    return table
-
-
-def gather_columns_types(domain, fxf):
-    """
-    Gather the column headers and their types
-
-    Args:
-        domain (str): A domain cname
-        fxf (str): An identifier for a dataset
-
-    Returns:
-        A list of pairs of containing a column name and a column type
-    """
-    url = 'http://{}/api/views/{}/columns.json'.format(domain, fxf)
-    response = requests.get(url)
-
-    try:
-        response.raise_for_status()
-    except HTTPError:
-        response_body = []
-    else:
-        response_body = response.json()
-
-        if isinstance(response_body, dict) and "error" in response_body:
-            response_body = []
-
-    def extract(column):
-        return (column.get("name"), column.get("fieldName"), column.get("dataTypeName"))
-
-    return [extract(column) for column in response_body]
-
-
-def _transform_cetera_result(result, result_position, num_columns):
+def _transform_cetera_result(result, result_position, num_rows, num_columns):
     """
     Utility function for transforming Cetera result dictionary into something
     more suitable for the crowdsourcing task. Presently, we're grabbing name,
     link (ie. URL), and the first sentence of description.
+
+    Args:
+        result ():
+        result_position (int): The position of the result in the result set
+        num_rows (int): The number of rows to show in the dataset sample
+        num_columns (int): The number of columns to show in the dataset sample
+
+    Returns:
+        A dictionary of data for each result
     """
     desc = cleanup_description(result["resource"].get("description"))
     domain = result["metadata"]["domain"]
     fxf = result["resource"].get("id")
-    columns_types = gather_columns_types(domain, fxf)[:num_columns]
-    header, columns_names, datatypes = zip(*columns_types) if columns_types else ([], [], [])
-    rows = gather_rows(domain_cname, fxf, columns_names, datatypes, num_rows)
-    table = convert_to_table(header, rows)
-    table = table if table and len(table) < CROWDFLOWER_MAX_ROW_LENGTH else None
+    data_sample = make_dataset_sample(domain, fxf, num_rows, num_columns)
+
+    return {
+        "result_domain": domain,
+        "result_position": result_position,
+        "result_fxf": fxf,
+        "name": result["resource"].get("name"),
+        "link": result["link"],
+        "description": desc,
+        "sample": data_sample
+    }
 
 
-    return {"result_position": result_position,
-            "result_fxf": fxf,
-            "name": result["resource"].get("name"),
-            "link": result["link"],
-            "description": desc,
-            "domain_logo_url": None,  # legacy field
-            "sample": generate_dataset_sample(),
-            "_golden": False}  # we need this field to copy data from existing CrowdFlower job
-
-
-def raw_results_to_dataframe(group_results, group_id):
+def raw_results_to_dataframe(group_results, group_id, num_rows, num_columns):
     """
     Add group ID to raw results tuple.
 
-    We keep raw results around for posterity.
+    Notes:
+        1. We keep raw results around for posterity.
+        2. When domain is specified as "www.opendatanetwork.com" in the input, we replace it with
+           the source domain of the corresponding result
 
     Args:
         group_results (iterable): An iterable of results tuples as returned by get_cetera_results
         group_id (int): An identifier for the group of results
+        num_rows (int): The number of rows to show in the dataset sample
+        num_columns (int): The number of columns to show in the dataset sample
 
     Returns:
         An iterable of result dictionaries with the required and relevant metadata
     """
+    LOGGER.info("Transforming raw results")
+
     results = pd.DataFrame.from_records(
         [(results + (group_id,)) for results in group_results],
         columns=RAW_COLUMNS)
 
-    results["results"] = results["results"].apply(
-        lambda rs: [_transform_cetera_result(r[1], r[0]) for r in rs])
+    transform = partial(_transform_cetera_result, num_rows=num_rows, num_columns=num_columns)
+
+    results["results"] = results["results"].apply(lambda rs: [transform(r[1], r[0]) for r in rs])
+    results["query"] = results["query"].apply(str)
 
     return results
-
-
-_LOGO_UID_RE = re.compile(r"^[A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}$")
-
-
-def get_domain_image(domain):
-    """
-    Get the site logo for the specified domain.
-
-    Args:
-        domain (str): The domain cname
-
-    Returns:
-        A URL to the domain's logo
-    """
-    url = 'http://{0}/api/configurations.json'.format(domain)
-
-    params = {'type': 'site_theme',
-              'defaultOnly': True,
-              'merge': True}
-
-    response = None
-
-    try:
-        response = requests.get(url, params=params, timeout=(5, 10))
-        response.encoding = 'utf-8'
-        response.raise_for_status()
-
-        data = next((x for x in response.json()[0]["properties"]
-                     if "name" in x and x["name"] == "theme_v2b"))
-
-        url = data.get("value", {}).get("images", {}).get("logo_header", {}) \
-                                                     .get("href")
-
-        if url and _LOGO_UID_RE.match(url):
-            url = "/api/assets/{0}".format(url)
-
-        if not (url.startswith("http") or url.startswith("https")):
-            url = "http://{0}{1}".format(domain, url)
-
-        return url
-
-    except IndexError as e:
-        print("Unexpected result shape: zero elements in response JSON")
-        print("Response: {}".format(response.content if response else None))
-        print("Exception: {}".format(e.message))
-    except StopIteration as e:
-        print("Unable to find image properties in response JSON")
-        print("Response: {}".format(response.content if response else None))
-        print("Exception: {}".format(e.message))
-    except Exception as e:
-        print("Failed to fetch configuration for %s" % domain)
-        print("Response: %s" % response.content if response else None)
-        print("Exception: %s" % e.message)
 
 
 def filter_previously_judged(db_conn, qrps_df):
@@ -428,15 +130,21 @@ def filter_previously_judged(db_conn, qrps_df):
         lambda row: (row["query"], row["result_fxf"]) not in previously_judged, axis=1)]
 
 
-def expanded_results_dataframe(raw_results, logos):
+def expanded_results_dataframe(raw_results):
     """
     Stack raw results column and join with `raw_results` dataframe such that we have one
-    query-result pair per row, add in domain-logos, and write to CSV.
+    query-result pair per row.
+
+    Args:
+        raw_results (pandas.DataFrame): A DataFrame with queries and results
+
+    Returns:
+        An expanded DataFrame with on query-result pair per row
     """
     # create new series by stacking/expanding results list
     results_s = raw_results["results"].apply(lambda rs: pd.Series(rs))
 
-    # drop unnecessary index, reset index to jybe w/ raw_results_df, and create new dataframe
+    # drop unnecessary index, reset index to jibe w/ raw_results_df, and create new dataframe
     expanded_results_df = pd.DataFrame(
         {"result": results_s.unstack().reset_index(level=0, drop=True)})
 
@@ -452,10 +160,14 @@ def expanded_results_dataframe(raw_results, logos):
     results_dict_df.set_index(expanded_results_df.index, inplace=True)
     expanded_results_df = expanded_results_df.join(results_dict_df)
 
+    # drop original domain, and replace with result domain
+    expanded_results_df = expanded_results_df.drop("domain", 1)
+    expanded_results_df = expanded_results_df.rename(columns={"result_domain": "domain"})
+
     return expanded_results_df
 
 
-def collect_search_results(groups, query_domain_file, num_results,
+def collect_search_results(groups, query_domain_file, num_results, num_rows, num_columns,
                            output_file=None, cetera_host=None, cetera_port=None):
     """
     Send queries included in `query_domain_file` to Cetera, collecting n=num_results results
@@ -463,9 +175,11 @@ def collect_search_results(groups, query_domain_file, num_results,
     to a CSV.
 
     Args:
-        groups (iterable): An iterable of GroupDefinitions
+        groups (Iterable[GroupDefinition]): An iterable of GroupDefinitions
         query_domain_file (str): A 2-column tab-delimited file containing query-domain pairs
         num_results (int): The number of search results to fetch for each query
+        num_rows (int): The number of rows to show in the dataset sample
+        num_columns (int): The number of columns to show in the dataset sample
         output_file (str): An optional file path to which the job CSV is to be written
         cetera_host (str): An optional Cetera hostname
         cetera_port (int): An optional Cetera port number
@@ -479,8 +193,8 @@ def collect_search_results(groups, query_domain_file, num_results,
     LOGGER.info("Reading query domain pairs from {}".format(query_domain_file))
 
     with open(query_domain_file, "r") as f:
-        next(f)
-        domain_queries = [x.strip().split('\t')[:2] for x in f if x.strip()]
+        next(f)  # skip header
+        domain_queries = [tuple(x.strip().split('\t')[:2]) for x in f if x.strip()]
 
     raw_results_df = pd.DataFrame(columns=RAW_COLUMNS)
 
@@ -490,12 +204,12 @@ def collect_search_results(groups, query_domain_file, num_results,
                                      num_results=num_results, cetera_params=group.params)
 
         raw_results_df = pd.concat(
-            [raw_results_df, raw_results_to_dataframe(results, group.id, logos)])
+            [raw_results_df, raw_results_to_dataframe(results, group.id, num_rows, num_columns)])
 
     output_file = output_file or \
         "{}-full.csv".format(datetime.now().strftime("%Y%m%d"))
 
-    expanded_results_df = expanded_results_dataframe(raw_results_df, logos)[CSV_COLUMNS]
+    expanded_results_df = expanded_results_dataframe(raw_results_df)[CSV_COLUMNS]
     expanded_results_df.to_csv(output_file, encoding="utf-8")
 
     return raw_results_df, expanded_results_df
@@ -506,7 +220,7 @@ def submit_job(db_conn, groups, data_df, output_file=None, job_to_copy=None):
     Create CrowdFlower job for catalog search result data in `data_df`.
 
     An external CrowdFlower ID is created by launching an initial empty job (using a previous job
-    (including settings and test data) as the initial state. After creating an CrowdFlower job and
+    (including settings and test data) as the initial state. After creating a CrowdFlower job and
     getting an external ID, we persist the job itself to the DB
 
     Args:
@@ -615,7 +329,7 @@ def persist_job_data(db_conn, job, groups, raw_data_df):
     raw_data_df.drop("payload", axis=1, inplace=True)
 
 
-def arg_parser():
+def parse_args():
     parser = argparse.ArgumentParser(
         description='Gather domains and queries from parsed nginx logs, '
         'gather the top n results from cetera')
@@ -658,21 +372,11 @@ def arg_parser():
 
 
 def main():
-    """
-    - read domain query pairs from file specified at the command-line
-    - create and persist groups defined at the command-line
-    - collect results for queries in each group
-    - combine data from each group
-    - filter out previously judged QRPs
-    - write all data to CSV
-    - create CrowdFlower job from CSV
-    - persist all data to DB for posterity
-    """
-    args = arg_parser()
+    args = parse_args()
 
     db_conn = psycopg2.connect(args.db_conn_str)
 
-    groups = args.groups or [GroupDefinition("baseline", "", {})]
+    groups = args.groups or [GroupDefinition(name="baseline", description="", params={})]
     groups = [insert_empty_group(db_conn, group) for group in groups]
 
     raw_results_df, expanded_results_df = collect_search_results(

--- a/arcs/launch_job.py
+++ b/arcs/launch_job.py
@@ -267,7 +267,12 @@ def submit_job(db_conn, groups, data_df, output_file=None, job_to_copy=None):
     try:
         add_data_to_job(job.external_id, output_file)
     except Exception as e:
-        LOGGER.warn("Unable to send CSV to CrowdFlower: {}".format(e.message))
+        if hasattr(e, "message"):
+            msg = "Unable to send CSV to CrowdFlower: {}".format(e.message)
+        else:
+            msg = "Unable to send CSV to CrowdFlower"
+
+        LOGGER.warn(msg)
         LOGGER.warn("Try uploading the data manually using the web UI.")
 
     LOGGER.info("Job submitted.")
@@ -363,13 +368,10 @@ def parse_args():
                         type=int,
                         default=5)
 
-    parser.add_argument('-c', '--cetera_host', dest='cetera_host',
-                        default='https://api.us.socrata.com/api/catalog/v1',
-                        help='Cetera hostname (eg. localhost) \
-                        default %(default)s')
+    parser.add_argument('-c', '--cetera_host',
+                        help='Cetera hostname (eg. localhost) default %(default)s')
 
-    parser.add_argument('-p', '--cetera_port', dest='cetera_port',
-                        default='80',
+    parser.add_argument('-p', '--cetera_port',
                         help='Cetera port, default %(default)s')
 
     parser.add_argument('-g', '--group', dest='groups', type=GroupDefinition.from_json,

--- a/arcs/launch_job.py
+++ b/arcs/launch_job.py
@@ -353,6 +353,16 @@ def parse_args():
                         help='Number of results per (domain, query) pair to fetch from cetera, \
                         default %(default)s')
 
+    parser.add_argument('--num_rows',
+                        help='Number of rows to limit the sample to, default %(default)s',
+                        type=int,
+                        default=5)
+
+    parser.add_argument('--num_columns',
+                        help='Number of columns to limit the sample to, default %(default)s',
+                        type=int,
+                        default=5)
+
     parser.add_argument('-c', '--cetera_host', dest='cetera_host',
                         default='https://api.us.socrata.com/api/catalog/v1',
                         help='Cetera hostname (eg. localhost) \
@@ -380,7 +390,7 @@ def main():
     groups = [insert_empty_group(db_conn, group) for group in groups]
 
     raw_results_df, expanded_results_df = collect_search_results(
-        groups, args.input_file, args.num_results,
+        groups, args.input_file, args.num_results, args.num_rows, args.num_columns,
         args.full_csv_file, args.cetera_host, args.cetera_port)
 
     job = submit_job(

--- a/arcs/logparser.py
+++ b/arcs/logparser.py
@@ -158,22 +158,15 @@ if __name__ == "__main__":
                 recs_of_interest += 1
 
                 try:
-                    print json.dumps(record, cls=__JSONDateEncoder__)
+                    print(json.dumps(record, cls=__JSONDateEncoder__))
                 except Exception as e:
-                    print >> sys.stderr, "{}".format(e.message)
+                    print("{}".format(e.message), file=sys.stderr)
 
     total_time = time.time() - start
 
-    print >> sys.stderr, "Lines read: {}".format(lines_read)
-    print >> sys.stderr, "Number of records of interest: {}".format(
-        recs_of_interest)
-
-    print >> sys.stderr, "Total time: {} secs.".format(total_time)
-    print >> sys.stderr, "Lines per sec: {}".format(
-        lines_read / float(total_time))
-
-    print >> sys.stderr, "Earliest datetime found: {}".format(
-        earliest_timestamp.isoformat())
-
-    print >> sys.stderr, "Latest datetime found: {}".format(
-        latest_timestamp.isoformat())
+    print("Lines read: {}".format(lines_read), file=sys.stderr)
+    print("Number of records of interest: {}".format(recs_of_interest), file=sys.stderr)
+    print("Total time: {} secs.".format(total_time), file=sys.stderr)
+    print("Lines per sec: {}".format(lines_read / float(total_time)), file=sys.stderr)
+    print("Earliest datetime found: {}".format(earliest_timestamp.isoformat()), file=sys.stderr)
+    print("Latest datetime found: {}".format(latest_timestamp.isoformat()), file=sys.stderr)

--- a/arcs/summarize_results.py
+++ b/arcs/summarize_results.py
@@ -116,12 +116,6 @@ def precision(judged_data):
     Returns:
         A floating point value corresponding to the precision of the result set.
     """
-    # filter out un-judged queries
-    judged_group_df = judged_data[judged_data["judgment"].notnull()]
-
-    # filter out QRPs with "something went wrong" judgments
-    judged_group_df = judged_data[judged_data["judgment"] >= 0]
-
     return (len(judged_data[judged_data["judgment"] >= 1]) /
             float(len(judged_data))) if len(judged_data) else 1.0
 

--- a/arcs/summarize_results.py
+++ b/arcs/summarize_results.py
@@ -213,7 +213,7 @@ def main(db_conn_str, group_1_id, group_2_id):
     experiment_stats["num_unique_qrps"] = unique_qrps
     experiment_stats["ndcg_delta"] = (ndcgs[1] - ndcgs[0])
 
-    print simplejson.dumps(experiment_stats, indent=4 * ' ')
+    print(simplejson.dumps(experiment_stats, indent=4 * ' '))
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -9,18 +9,16 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-install_requires_list = ['pandas==0.17.0',
-                         'matplotlib==1.4.3',
-                         'numpy==1.10.1',
-                         'frozendict==0.4',
-                         'simplejson==3.7.3',
-                         'requests[security]==2.7.0',
+install_requires_list = ['pandas>=0.18.1',
+                         'matplotlib>=1.5',
+                         'numpy>=1.11.0',
+                         'frozendict>=0.6',
+                         'simplejson>=3.8.2',
+                         'requests[security]>=2.10.0',
                          'psycopg2==2.6.1',
-                         'langdetect==1.0.5',
-                         'crowdflower==0.1.3',
-                         'scipy==0.16.0',
-                         'spacy==0.99']
-
+                         'langdetect>=1.0.6',
+                         'scipy>=0.17.1',
+                         'spacy>=0.100']
 
 
 class PyTest(TestCommand):
@@ -48,8 +46,8 @@ setup(
     include_package_data=True,
     name="arcs",
     version="0.0.1",
-    author="The AniML pack at Socrata",
-    author_email="animl@socrata.com",
+    author="The Discovery Team",
+    author_email="discovery-l@socrata.com",
     description=("A library for assessing relevance of Socrata's catalog "
                  "search"),
     license = "TBD",

--- a/task_templates/crowdflower_instructions.html
+++ b/task_templates/crowdflower_instructions.html
@@ -1,0 +1,168 @@
+<div class="row-fluid">
+  <div class="span10 offset1">
+
+    <h3><strong>Overview</strong></h3>
+    <div class="cml-section_body">
+      <div class="row-fluid">
+
+	<p>Our search engine helps you find publicly available datasets. These datasets are made available by diverse public agencies all the way from city government to the White House. Your task is to help us improve our search engine by determining how relevant certain datasets are to a corresponding query that a user entered on a particular domain in our system.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<hr>
+<div class="row-fluid">
+  <div class="span10 offset1">
+
+    <h3><strong>We Provide</strong></h3>
+    <div class="cml-section_body">
+
+      <ul>
+	<li>
+
+	  <h4 class="your_tools-resource_header">A Search Query and Domain</h4>
+
+	  <ul>
+	    <li>The search query is an <strong>actual search query</strong> that a user has <strong>entered into a search box</strong>.</li>
+	    <li>The query may either be a keyword search ("Seattle high school test scores") or a category search ("category=Education").</li>
+	  </ul>
+	</li>
+	<br>
+	<li>
+
+	  <h4 class="your_tools-resource_header">A Result, which contains:</h4>
+
+	  <ul>
+	    <li>Dataset Name</li>
+	    <li>Dataset Description</li>
+	    <li>Link to data on the site that provides it</li>
+	    <li>Data sample (when available)</li>
+	  </ul>
+	</li>
+	<br>
+	<li>
+
+	  <h4 class="your_tools-resource_header">Options to select the level of relevance</h4>
+	</li>
+      </ul>
+    </div>
+  </div>
+</div>
+<hr>
+<div class="row-fluid">
+  <div class="span10 offset1">
+
+    <h3><strong>Process</strong></h3>
+    <div class="cml-section_body">
+      <div class="row-fluid">
+	<div class="span8">
+
+	  <ol>
+	    <li><strong>Read and Understand</strong> the search query</li>
+	    <br>
+	    <li><strong>Review</strong> the result of each query</li>
+	    <br>
+	    <li><strong>Select</strong> the level of relevance for each result.
+
+	      <ul>
+		<li>Sometimes it will be hard to determine whether a dataset is relevant to the search query given just the description and the title. In those cases, click on the link to view the dataset itself (this should automatically open in a new tab in your browser, which you can then close). This may help you determine how relevant it is.</li>
+	      </ul>
+	    </li>
+	  </ol>
+	</div>
+      </div>
+    </div>
+  </div>
+</div>
+<hr>
+<div class="row-fluid">
+  <div class="span10 offset1">
+
+    <h3><strong>Rules and Tips</strong></h3>
+    <div class="cml-section_body">
+      <div class="row-fluid">
+	<div class="span11">
+
+	  <ul>
+	    <li>You should be assessing the results based on the <strong>intent of the query.</strong>&nbsp;
+
+	      <ul>
+		<li>Intent is the purpose of the search
+
+		  <ul>
+		    <li>If a person is searching for '<strong>political contributions</strong>', the intent of that search is to find datasets with information about contributions to political campaigns. If the result is a dataset containing healthcare data, we could say that the result is <strong>Irrelevant</strong>.</li>
+		    <li>If a person searches for '<strong>crimes by neighborhood</strong>', and the result is a dataset with crime data that includes details about the location of the crime, we could say that the result is <strong>Excellent</strong>.</li>
+		    <li>If a person searches for <strong>category=Education</strong>, they are hoping to find general datasets relevant to the category of Education.</li>
+		  </ul>
+		</li>
+	      </ul>
+	    </li>
+	    <br>
+	    <li>Review the information we've provided before making your decision.</li>
+	    <br>
+	    <hr>
+
+	    <h3><strong>Relevance Definitions</strong></h3>
+	    <li>You should choose <strong>Irrelevant</strong> if:
+
+	      <ul>
+		<li>The intent of the query was not matched.</li>
+		<li>The results are irrelevant to the search query</li>
+		<li><strong><span style="color:blue">"Why is this item even being returned?"</span></strong></li>
+	      </ul>
+	    </li>
+	    <br>
+	    <li>Choose <strong>Loosely relevant</strong> if:
+
+	      <ul>
+		<li>The intent of the query is poorly matched.</li>
+		<li>The result is somewhat related to the query, but it not a good match.</li>
+		<li><strong><span style="color:blue">"I see why this is returned but it's definitely not what I wanted – I probably would not click on this result."</span></strong></li>
+	      </ul>
+	    </li>
+	    <br>
+	    <li>Choose <strong>Relevant</strong> if:
+
+	      <ul>
+		<li>Matches most of the query intent - or the most important part of the query.</li>
+		<li>Technically, all parts of the intent are satisfied but result doesn't provide a full, clear and complete answer to the search.</li>
+		<li><strong><span style="color:blue">"This broadly matches what I searched for, but it’s not a perfect match"</span></strong></li>
+	      </ul>
+	    </li>
+	    <br>
+	    <li>Choose <strong>Excellent</strong> if:
+
+	      <ul>
+		<li>The query intent is clearly satisfied.</li>
+		<li><strong>Specifics</strong> of the Query appear in the Result</li>
+		<li><strong><span style="color:blue">"This is exactly what I was looking for"</span></strong></li>
+	      </ul>
+	    </li>
+	    <br>
+	    <li>Choose <strong>Something went wrong / not enough information</strong> if:
+
+	      <ul>
+		<li>the result title and/or description are missing and the link is broken</li>
+		<li>the result title and/or description text are in a foreign language</li>
+		<li><strong><span style="color:blue">"I don't understand the result"</span></strong></li>
+	      </ul>
+	    </li>
+	  </ul>
+	</div>&nbsp;</div>
+    </div>
+  </div>
+</div>
+<hr>
+<div class="row-fluid">
+  <div class="span10 offset1">
+
+    <h3><strong>Thank you!</strong></h3>
+    <div class="cml-section_body">
+      <div class="row-fluid">
+	<div class="span10">
+
+	  <p>Thank you for your hard work in this task! Your efforts are greatly appreciated.</p>
+	</div>&nbsp;</div>
+    </div>
+  </div>
+</div>

--- a/task_templates/crowdflower_template.html
+++ b/task_templates/crowdflower_template.html
@@ -1,0 +1,56 @@
+<div class="row-fluid">
+  <div class="span12">
+    <br />
+    <div class="row-fluid center-text" style="position:relative">
+      <div class="span4 well megaspan">
+        <h1 class="cml-blue">Query</h1>
+        <h3>The search term is:</h3>
+        <br />
+        <h2 id="searchbox" >{{query}}</h2>
+      </div>
+      <div class="span8 well megaspan">
+        <h1 class="cml-green">Result</h1>
+        <hr />
+        <h2 class="special pad-line">
+          <strong>{{name}}</strong>
+        </h2>
+        <p class="special pad-line">{{description}}</p>
+        <a target="_blank" href="{{link}}">
+          <i>Link to the original data from
+            <b>{{domain}}</b>
+          </i>
+        </a>
+        <br />
+        <div>
+          {{sample}}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <br clear="both" />
+  <br clear="both" />
+
+</div>
+
+<hr />
+
+<div class="row-fluid center-text" style="position:relative">
+  <cml:radios label="How well does this &lt;font class=&quot;   cml-green&quot;&gt;result&lt;/font&gt; match the &lt;font class=&quot;   cml-blue&quot;&gt;query&lt;/font&gt;? &lt;br /&gt; &lt;br /&gt;" name="relevance" validates="required" gold="true" aggregation="avg">
+
+    <cml:radio label="&lt;span class=&quot;label_term&quot;&gt; Irrelevant&lt;/span&gt;&lt;br /&gt;&lt;br /&gt; &lt;div class=&quot;pad_me&quot;&gt; &lt;span class=&quot;instructions_fake&quot;&gt;      &lt;li&gt; The intent of the query was not matched &lt;/li&gt;      &lt;li&gt; The results are irrelevant to the search query &lt;/li&gt;  &lt;/span&gt; &lt;div&gt;" value="0"></cml:radio>
+
+    <cml:radio label="&lt;span class=&quot;label_term&quot;&gt; Loosely relevant&lt;/span&gt;&lt;br /&gt;&lt;br /&gt; &lt;div class=&quot;pad_me&quot;&gt; &lt;span class=&quot;instructions_fake&quot;&gt;      &lt;li&gt; The intent of the query is poorly matched &lt;/li&gt;     &lt;li&gt; The result is somewhat related to the query, but it not a good match &lt;/li&gt;     &lt;/span&gt; &lt;div&gt;" value="1"></cml:radio>
+
+    <cml:radio label="&lt;span class=&quot;label_term&quot;&gt; Relevant&lt;/span&gt;&lt;br /&gt;&lt;br /&gt; &lt;div class=&quot;pad_me&quot;&gt; &lt;span class=&quot;instructions_fake&quot;&gt;     &lt;li&gt; Matches most of the query intent - or the most important part of the query. &lt;/li&gt;     &lt;li&gt; Technically, all parts of the intent are satisfied but result doesn't provide a full, clear and complete answer to the search. &lt;/li&gt;     &lt;/span&gt; &lt;div&gt;" value="2"></cml:radio>
+
+    <cml:radio label="&lt;span class=&quot;label_term&quot;&gt; Extremely relevant&lt;/span&gt;&lt;br /&gt;&lt;br /&gt; &lt;div class=&quot;pad_me&quot;&gt; &lt;span class=&quot;instructions_fake&quot;&gt;     &lt;li&gt; The query intent is clearly satisfied. This is exactly the product I was looking for &lt;/li&gt;      &lt;li&gt; Result is high quality &lt;/li&gt;     &lt;li&gt; Specifics of the Query appear in the Result  &lt;/li&gt;       &lt;/span&gt; &lt;div&gt;" value="3"></cml:radio>
+
+    <cml:radio label="&lt;span class=&quot;label_term&quot;&gt; Something went wrong / not enough information&lt;/span&gt;&lt;br /&gt;&lt;br /&gt; &lt;div class=&quot;pad_me&quot;&gt; &lt;span class=&quot;instructions_fake&quot;&gt;     &lt;li&gt; the result title and/or description are missing and the link is broken &lt;/li&gt;      &lt;li&gt; the result title and/or description text are in a foreign language &lt;/li&gt;       &lt;/span&gt; &lt;div&gt;" value="-1"></cml:radio>
+
+
+  </cml:radios>
+</div>
+<br clear="both" />
+<br />
+<hr />

--- a/task_templates/styles.css
+++ b/task_templates/styles.css
@@ -1,0 +1,148 @@
+tr:nth-child(even) {background-color: #f2f2f2}
+
+th {
+    background-color: #288dc1;
+    color: white;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+table, th, td {
+    border: 1px solid #63656A;
+    padding: 2px;
+}
+
+#searchbox {
+  border-radius: 5px;
+  border: 1px solid #d3d3d3d3;
+  margin: 5px;
+  padding: 7px;
+  background-color: #ffffff;
+}
+
+/* from base */
+
+.cml-blue {
+  color: #00A6E0;
+}
+
+.cml-yellow {
+  color: #ffcb02;
+}
+
+.pad_me {
+  padding: 0px 15px;
+}
+
+.cml-right {
+  text-align: right;
+}
+
+.cml-green {
+  color: #8CC63E;
+}
+
+div.result .title a {
+  color: #12C !important;
+  text-decoration: underline !important;
+}
+
+div.result .cite {
+  color: #093 !important;
+}
+
+div.search {
+ border: 2px solid black !important;
+ padding: 5px !important;
+}
+
+div.mini_search {
+ border: 2px solid black !important;
+ display: inline-block;
+}
+
+
+div.left {
+ float: left !important;
+ width: 300px !important;
+}
+
+div.right {
+ margin-left: 20px;
+ padding: 5px !important;
+ float: left !important;
+ width: 450px !important;
+}
+
+.label_term {
+  margin-left: 0%; 
+  font-weight: bold;
+  position: inline-block;
+}
+
+.cml .cml_field .instructions {
+    color: #FFFFFF;
+}
+
+.cml .cml_field .required {
+  display: none;
+}
+
+.radios.cml_field .cml_row {
+  float: left;
+  width: 25%;
+ }
+
+.cml_row_small {
+  width: 20%; 
+  float: left;
+}
+
+
+.seventy {
+  width: 70%; 
+  margin: auto;
+}
+
+
+.term { 
+  font-weight: bold; 
+  background-color: #FDFFC2; 
+}
+
+.instructions_fake { 
+  color: #333;
+  font-size: 70%;
+}
+
+  
+  
+padding-top: 3px; 
+
+  
+  -webkit-box-shadow: 0 8px 6px -6px black;
+  -moz-box-shadow: 0 8px 6px -6px black;
+  box-shadow: 0 8px 6px -6px black; 
+}
+.radios.cml_field .cml_row {
+  margin-top: 10px;
+
+}
+
+/*
+.megaspan{
+  height: 350px;
+  text-align: center;
+}
+*/
+
+
+.padme {
+  padding: 5px;
+}
+
+.pad-line
+  line-height: 150%
+}


### PR DESCRIPTION
This changeset includes modifications to make arcs work in Python3. Additionally, and more importantly, it adds support for the category/search facet relevance jobs (specifically, to allow us to compare relevance on category facet queries w/ old and new clads).
